### PR TITLE
Fixes Deprecated Notice in PHP 81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 Changelog
 =========
 
-#### 4.5.11 - Gen 09, 2023
+#### 4.5.12 - Gen 09, 2024
+
+**Fixes**
+
+- PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in Newsletter-for-Wordpress/includes/api/xmlrpc.inc on line 2444
+- Added check to evaluate empty array value in Newsletter-for-Wordpress/includes/api/xmlrpc.inc on line 2444
+- Changed wrong date in Changelog entry
+
+
+#### 4.5.11 - Gen 09, 2024
 
 **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+#### 4.5.11 - Gen 09, 2023
+
+**Fixes**
+
+- PHP Deprecated:  Return type of NL4WP_Container::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset)
+- PHP Deprecated:  Return type of NL4WP_Container::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset)
+- PHP Deprecated:  Return type of NL4WP_Container::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value)
+- PHP Deprecated:  Return type of NL4WP_Container::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset)
+- Added attribute #[\ReturnTypeWillChange] to NL4WP_Container for Deprecated notices in PHP 8.1
+
+
 #### 4.5.5 - Sep 12, 2019
 
 **Fixes**

--- a/includes/api/xmlrpc.inc
+++ b/includes/api/xmlrpc.inc
@@ -2441,7 +2441,11 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 								{
 									$val = explode('=', $val, 2);
 									$tag = trim($val[0]);
-									$val = trim(@$val[1]);
+									if ( isset($val[1]) && ! empty($val[1]) ) {
+										$val = trim(@$val[1]);
+									} else {
+										$val = '';
+									}
 									/// @todo with version 1 cookies, we should strip leading and trailing " chars
 									if ($pos == 0)
 									{

--- a/includes/class-container.php
+++ b/includes/class-container.php
@@ -70,6 +70,7 @@ class NL4WP_Container implements ArrayAccess
      * <p>
      * The return value will be casted to boolean if non-boolean was returned.
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->has($offset);
@@ -86,6 +87,7 @@ class NL4WP_Container implements ArrayAccess
      *
      * @return mixed Can return all value types.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
@@ -105,6 +107,7 @@ class NL4WP_Container implements ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->services[ $offset ] = $value;
@@ -121,6 +124,7 @@ class NL4WP_Container implements ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->services[ $offset ]);

--- a/newsletter-for-wp.php
+++ b/newsletter-for-wp.php
@@ -3,7 +3,7 @@
 Plugin Name: Newsletter for WordPress
 Plugin URI: https://github.com/mailrouter/Newsletter-for-Wordpress
 Description: Newsletter for WordPress by mailrouter. Aggiunge vari metodi di iscrizione newsletter al tuo sito.
-Version: 4.5.11
+Version: 4.5.12
 Author: mailrouter
 Text Domain: newsletter-for-wp
 Domain Path: /languages

--- a/newsletter-for-wp.php
+++ b/newsletter-for-wp.php
@@ -3,7 +3,7 @@
 Plugin Name: Newsletter for WordPress
 Plugin URI: https://github.com/mailrouter/Newsletter-for-Wordpress
 Description: Newsletter for WordPress by mailrouter. Aggiunge vari metodi di iscrizione newsletter al tuo sito.
-Version: 4.5.10
+Version: 4.5.11
 Author: mailrouter
 Text Domain: newsletter-for-wp
 Domain Path: /languages

--- a/newsletter-for-wp.php
+++ b/newsletter-for-wp.php
@@ -57,11 +57,11 @@ function _nl4wp_load_plugin()
     }
 
     // bootstrap the core plugin
-    define( 'NL4WP_VERSION', '4.5.10');
+    define( 'NL4WP_VERSION', '4.5.12');
     /* NL_CHANGED - start
      * imposta la versione pro
      */
-    define ('NL4WP_PREMIUM_VERSION', '4.5.10');
+    define ('NL4WP_PREMIUM_VERSION', '4.5.12');
     /* NL_CHANGED - end */
     define('NL4WP_PLUGIN_DIR', dirname(__FILE__) . '/');
     define('NL4WP_PLUGIN_URL', plugins_url('/', __FILE__));


### PR DESCRIPTION
Hi i pushed this fixes for the following notices when migrating to PHP 81

```
PHP Deprecated:  Return type of NL4WP_Container::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Newsletter-for-Wordpress/includes/class-container.php on line 73
PHP Deprecated:  Return type of NL4WP_Container::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Newsletter-for-Wordpress/includes/class-container.php on line 89
PHP Deprecated:  Return type of NL4WP_Container::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Newsletter-for-Wordpress/includes/class-container.php on line 108
PHP Deprecated:  Return type of NL4WP_Container::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Newsletter-for-Wordpress/includes/class-container.php on line 124
```